### PR TITLE
Add accessor to current partition ids

### DIFF
--- a/bundles/de.uka.ipd.sdq.workflow/src/de/uka/ipd/sdq/workflow/blackboard/Blackboard.java
+++ b/bundles/de.uka.ipd.sdq.workflow/src/de/uka/ipd/sdq/workflow/blackboard/Blackboard.java
@@ -1,6 +1,7 @@
 package de.uka.ipd.sdq.workflow.blackboard;
 
 import java.util.HashMap;
+import java.util.Set;
 
 /**
  * A blackboard is a storage space where workflow jobs can retrieve and store data from respectively
@@ -67,6 +68,11 @@ public class Blackboard<T> implements IBlackboard<T> {
     @Override
     public void removePartition(String id) {
         blackboardStore.remove(id);
+    }
+    
+    @Override
+    public Set<String> getPartitionIds() {
+        return blackboardStore.keySet();
     }
 
 }

--- a/bundles/de.uka.ipd.sdq.workflow/src/de/uka/ipd/sdq/workflow/blackboard/IBlackboard.java
+++ b/bundles/de.uka.ipd.sdq.workflow/src/de/uka/ipd/sdq/workflow/blackboard/IBlackboard.java
@@ -1,5 +1,7 @@
 package de.uka.ipd.sdq.workflow.blackboard;
 
+import java.util.Set;
+
 /**
  * Interface of a blackboard as defined in POSA I. See also class Blackboard for further information.
  *
@@ -36,4 +38,12 @@ public interface IBlackboard<T> {
 	 * @param id ID of the partition to removeS
 	 */
 	void removePartition(String id);
+	
+	/**
+	 * Get the set of partitions currently present on this blackboard.
+	 * 
+	 * @return the set of partition ids.
+	 */
+	Set<String> getPartitionIds();
+	
 }

--- a/tests/de.uka.ipd.sdq.workflow.mdsd.tests/src/de/uka/ipd/sdq/workflow/mdsd/tests/MDSDBlackboardTests.java
+++ b/tests/de.uka.ipd.sdq.workflow.mdsd.tests/src/de/uka/ipd/sdq/workflow/mdsd/tests/MDSDBlackboardTests.java
@@ -20,6 +20,9 @@ import de.uka.ipd.sdq.workflow.mdsd.blackboard.ResourceSetPartition;
 import de.uka.ipd.sdq.workflow.mdsd.blackboard.SavePartitionToDiskJob;
 import de.uka.ipd.sdq.workflow.mdsd.mocks.MockResourceSetPartition;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+
 public class MDSDBlackboardTests {
 
     MDSDBlackboard blackboard;
@@ -52,6 +55,8 @@ public class MDSDBlackboardTests {
 
         // partition should be present
         Assert.assertTrue(this.blackboard.hasPartition("testPartitionId"));
+        
+        assertThat(this.blackboard.getPartitionIds(), containsInAnyOrder("testPartitionId"));
 
         // model should be present for modelLocation
         final ModelLocation modelLocation = new ModelLocation("testPartitionId", modelURI);


### PR DESCRIPTION
Currently it is not possible to check which partitions are available on the blackboard. This PR adds an appropriate accessor the the IBlackboard interface. 