### PR TITLE
Fix wrong assumption in TabHelper

### DIFF
--- a/bundles/de.uka.ipd.sdq.workflow.launchconfig/src/de/uka/ipd/sdq/workflow/launchconfig/tabs/TabHelper.java
+++ b/bundles/de.uka.ipd.sdq.workflow.launchconfig/src/de/uka/ipd/sdq/workflow/launchconfig/tabs/TabHelper.java
@@ -47,11 +47,11 @@ public class TabHelper {
 			ILaunchConfigurationTabGroup tabGroup,
 			ILaunchConfigurationDialog dialog, String mode, Composite parent,
 			int style) {
-	    // This is to support the legacy behavior which violated the eclipse protocol.
-	    // The nested tabs need be created ahead of creating the controls to support providing defaults.
-	    if (tabGroup.getTabs() == null) {
-	        tabGroup.createTabs(dialog, mode);
-	    }
+		// This is to support the legacy behavior which violated the eclipse protocol.
+		// The nested tabs need be created ahead of creating the controls to support providing defaults.
+		if (tabGroup.getTabs() == null) {
+			tabGroup.createTabs(dialog, mode);
+		}
 		ILaunchConfigurationTab[] tabs = tabGroup.getTabs();
 
 		CTabFolder tabFolder = new CTabFolder(parent, style);

--- a/bundles/de.uka.ipd.sdq.workflow.launchconfig/src/de/uka/ipd/sdq/workflow/launchconfig/tabs/TabHelper.java
+++ b/bundles/de.uka.ipd.sdq.workflow.launchconfig/src/de/uka/ipd/sdq/workflow/launchconfig/tabs/TabHelper.java
@@ -47,7 +47,11 @@ public class TabHelper {
 			ILaunchConfigurationTabGroup tabGroup,
 			ILaunchConfigurationDialog dialog, String mode, Composite parent,
 			int style) {
-		tabGroup.createTabs(dialog, mode);
+	    // This is to support the legacy behavior which violated the eclipse protocol.
+	    // The nested tabs need be created ahead of creating the controls to support providing defaults.
+	    if (tabGroup.getTabs() == null) {
+	        tabGroup.createTabs(dialog, mode);
+	    }
 		ILaunchConfigurationTab[] tabs = tabGroup.getTabs();
 
 		CTabFolder tabFolder = new CTabFolder(parent, style);


### PR DESCRIPTION
The createTabFolder method of the tab helper simplifies embedding tab groups inside a launch configuration tab (e.g. used for the EDP2 repository selection). It is used during the creation of controls. Unfortunately, it assumes the tabs of a tab group are not yet created. This violates the protocol of Eclipse. The tabs are created before applying the default value to a launch config and thereafter, the controls are created. Currently, nested Tabs are not queried for their default values.

This change supports doing it right, while still providing legacy support.